### PR TITLE
Fix decimal formatting of minimum donation

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,5 +26,6 @@ function calculateTotal() {
     total = total < 0 ? 0 : total;
 
     // Display the total
-    document.getElementById("total").innerText = total;
+    var formatter = new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    document.getElementById("total").innerText = formatter.format(total);
 }


### PR DESCRIPTION
Hi, I noticed that the minimum donation isn't formatting US dollars quite right:

<img width="479" alt="Screenshot 2023-09-12 at 4 24 36 PM" src="https://github.com/bjbech/TheMarcoOffset/assets/313895/d75f54ce-942a-406f-ba39-837d4227665d">

This should do the trick. 🙌🏼 

Thanks for putting this site together! 😂 