### PR TITLE
Fix currency conversion

### DIFF
--- a/data/conversionRate.json
+++ b/data/conversionRate.json
@@ -1,6 +1,6 @@
 {
   "USA": 1.0,
-  "Canada": 1.39,
-  "United Kingdom": 0.74,
-  "Italy": 0.85
+  "Canada": 0.72,
+  "United Kingdom": 1.36,
+  "Italy": 1.17
 }


### PR DESCRIPTION
Commit a1b9a67 added the country selection feature. The rates given in conversionRate.json were in currency/USD but script.js calculates the USD offset by multiplying the foreign currency offset by the conversion rate. The result was that converted offsets were incorrect. EUR and GBP offsets were converted to a too-low USD offset and CAD offsets were converted to a more generous USD offset. For example, £307.88 was calculated as $227.83 instead of $418.72.

This commit fixes the problem by reversing the sense of the rates in conversionRate.json so they are now in USD/currency. Within rounding, the reciprocals of the old rates were equal to the values I looked up at around 2025-09-12T18:30+00:00. I chose to change the data over changing the calculation to avoid any possibility of a division-by-zero.